### PR TITLE
Report error line and position. Compute token boundaries.

### DIFF
--- a/JSON_checker.h
+++ b/JSON_checker.h
@@ -13,6 +13,7 @@ typedef struct JSON_checker_struct {
     int depth;
     int top;
     int* stack;
+    int start_token; /* 1 before, 2 after, 3 both */
 } * JSON_checker;
 
 

--- a/main.c
+++ b/main.c
@@ -19,7 +19,15 @@ int main(int argc, char* argv[]) {
 */
     int line_number = 1;
     int character_position = 0;
+    int at_token_start = 1;
+    int show_tokens = 0; /* Set to non-zero to write tokens separated by */
+    
     JSON_checker jc = new_JSON_checker(20);
+
+    if (argc > 1 && !strcmp(argv[1],"--show")) {
+        show_tokens = 1;
+    }
+
     for (;;) {
         int next_char = getchar();
         if (next_char <= 0) {
@@ -44,6 +52,22 @@ int main(int argc, char* argv[]) {
                     line_number, character_position, next_char);
             }
             exit(1);
+        }
+        /* 
+            Handle the flags for token start 
+         */
+        if (show_tokens) {
+            if (at_token_start || (jc->start_token & 1)) {
+                /* token starts before this character */
+                putchar('|');
+            }
+            putchar(next_char);
+        }
+        if (jc->start_token & 2) {
+            /* Token starts on next character */
+            at_token_start = 1;
+        } else {
+            at_token_start = 0;
         }
     }
     if (!JSON_checker_done(jc)) {

--- a/main.c
+++ b/main.c
@@ -17,14 +17,32 @@ int main(int argc, char* argv[]) {
 
     jc will contain a JSON_checker with a maximum depth of 20.
 */
+    int line_number = 1;
+    int character_position = 0;
     JSON_checker jc = new_JSON_checker(20);
     for (;;) {
         int next_char = getchar();
         if (next_char <= 0) {
             break;
         }
+        character_position += 1;
+        if (next_char == '\n') {
+            line_number++;
+            character_position = 0;
+        }
         if (!JSON_checker_char(jc, next_char)) {
-            fprintf(stderr, "JSON_checker_char: syntax error\n");
+            /* Got syntax error. Report it. */
+            if (next_char >= 0x20 
+                && next_char < 0x7f 
+                && next_char != '\'') {
+                fprintf(stderr,
+                    "JSON_checker_char:%d:%d syntax error at ('%c')",
+                    line_number, character_position, next_char);
+            } else {
+                fprintf(stderr,
+                    "JSON_checker_char:%d:%d syntax error at ('\\x%02x')",
+                    line_number, character_position, next_char);
+            }
             exit(1);
         }
     }


### PR DESCRIPTION
Thank you for publishing your work.

I hope you are able to merge these improvements.. I tried to be conservative (changing as little as possible and following your coding style.)

1. The error line number and position is a pretty simple change in main.c.  (Related: what would you think about a code change attempting to recover so that additional errors could be reported? Would you consider taking such a change after this one is merged?)

2. About the new code which computes token boundaries: Thank you very much for a state machine that was easy to understand!

Since this is not a look-ahead parser, the token boundary that is computed may be preceding the character being processed, after it, or both.  (For example, the closing \x22 of a string or the final character of a reserved word is after, most others are before. Separators, like ',', are both.)
Newline is not its own token. The newline and whitespace on the next line is included.

3. I was on the fence about how to get the location of the token boundary returned back to the caller. I decided to put it into the structure and let the caller access it. I like the idea of opaque structures in general, but you did not declare it opaque, so it was fair game to do it that way and not change the API. If you want, I would happily change the API to let the caller pass in a pointer.

4. A flag in main.c enables copying input to output and showing token boundaries with '|' as the separation character.  Takes --show option on the command line. This is not super-useful, but it is a good pattern of how to use the API.

5. I reviewed json.org to write up my test cases. I think the token boundary code correctly handles everything, but my test cases are probably not getting full coverage of the state machine.  Do you have any thoughts on including test cases in the project?


Thanks!
Forrest